### PR TITLE
genfilters: support for `--input-file` and other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You can interact with the user interface using key presses. The supported keys a
      d toggle debug mode (shows more info)
      r toggle showing the rules to the right of the tree
      c clear selections and start over
+     y copy current relative path to clipboard (if supported)
+     Y copy current absolute path to clipboard (if supported)
      q/ESC/^c to quit and output final results
 
 See flags for more options.
@@ -65,7 +67,8 @@ rclone genfilters remote:path [flags]
 ```
       --cmd                  Also show filters in command line syntax, to add the filters directly via the --filter flag instead of with a --filter-from file
   -h, --help                 help for genfilters
+      --input-file string    Load filters from this existing file on startup.
       --no-open              Do not automatically open the file when completed.
-  -o, --output-file string   Write results to a file at this path, for use as a --filter-from file. (default: {cachedir}/rclone_genfilters.txt)
+  -o, --output-file string   Write results to a file at this path, for use as a --filter-from file. (default: {currentdirectory}/rclone_genfilters.txt)
       --regex                Also show output as regex, in --dump filters format
 ```

--- a/cmd/genfilters/genfilters.go
+++ b/cmd/genfilters/genfilters.go
@@ -310,6 +310,12 @@ func GenFilters(ctx context.Context, f fs.Fs, infile, outfile string) error {
 			fs.Logf(nil, "%v", err)
 		}
 		refresh()
+		sort.Slice(files, func(i, j int) bool {
+			return strings.ToLower(files[i].Remote()) < strings.ToLower(files[j].Remote())
+		})
+		sort.Slice(dirs, func(i, j int) bool {
+			return strings.ToLower(dirs[i].Remote()) < strings.ToLower(dirs[j].Remote())
+		})
 		for _, dir := range dirs {
 			node := tview.NewTreeNode("🖿 " + withSlash(dir)).SetReference(dir).SetSelectable(true)
 			processNew(node)
@@ -476,7 +482,7 @@ func parse() ([]string, map[string]string) {
 	}
 	// reverse sort
 	sort.SliceStable(keys, func(i, j int) bool {
-		return keys[i] > keys[j]
+		return strings.ToLower(keys[i]) > strings.ToLower(keys[j])
 	})
 
 	root := "+ /*"

--- a/cmd/genfilters/genfilters.go
+++ b/cmd/genfilters/genfilters.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mattn/go-runewidth"
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs"
-	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/walk"
@@ -59,7 +58,7 @@ const (
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
 	cmdFlags := commandDefinition.Flags()
-	flags.StringVarP(cmdFlags, &outputfile, "output-file", "o", "", "Write results to a file at this path, for use as a --filter-from file. (default: {cachedir}/rclone_genfilters.txt)", "")
+	flags.StringVarP(cmdFlags, &outputfile, "output-file", "o", "", "Write results to a file at this path, for use as a --filter-from file. (default: {currentdirectory}/rclone_genfilters.txt)", "")
 	flags.BoolVarP(cmdFlags, &noOpen, "no-open", "", noOpen, "Do not automatically open the file when completed.", "")
 	flags.BoolVarP(cmdFlags, &showRegex, "regex", "", showRegex, "Also show output as regex, in --dump filters format", "")
 	flags.BoolVarP(cmdFlags, &showCmdLine, "cmd", "", showCmdLine, "Also show filters in command line syntax, to add the filters directly via the --filter flag instead of with a --filter-from file", "")
@@ -137,7 +136,7 @@ func setDefaults() {
 		defaultInclude = false // selected = included
 	}
 	if outputfile == "" {
-		outputfile = filepath.Join(config.GetCacheDir(), "rclone_genfilters.txt")
+		outputfile = filepath.Join(".", "rclone_genfilters.txt")
 	}
 }
 

--- a/cmd/genfilters/genfilters.go
+++ b/cmd/genfilters/genfilters.go
@@ -430,6 +430,8 @@ func GenFilters(ctx context.Context, f fs.Fs, infile, outfile string) error {
 
 	// handles the box on the left which shows the resulting rules in realtime
 	tree.Box.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		half := width / 2
+
 		// draw text
 		style := tcell.StyleDefault.Reverse(false)
 		toPrint := rules
@@ -440,10 +442,10 @@ func GenFilters(ctx context.Context, f fs.Fs, infile, outfile string) error {
 			toPrint = append(toPrint, rulesCmdLine...)
 		}
 		for i, s := range toPrint {
-			line(x, y+i, 30, style, ' ', s, screen)
+			line(x, y+i, half-5, style, ' ', s, screen)
 			style = tcell.StyleDefault.Reverse(false)
 		}
-		return x + 35, y, width - 30, height
+		return x + half, y, width - (half + 5), height
 	})
 
 	// create the app and run it

--- a/cmd/genfilters/genfilters.go
+++ b/cmd/genfilters/genfilters.go
@@ -598,6 +598,7 @@ func outputFile(filename, rulesString string) {
 	header += "# see https://rclone.org/filtering/#filter-from-read-filtering-patterns-from-a-file\n\n"
 	header += fmt.Sprintf("# rclone bisync remote1:path1 remote2:path2 --create-empty-src-dirs --compare size,modtime,checksum --slow-hash-sync-only --resilient -MvP --drive-skip-gdocs --fix-case --resync --dry-run --filters-file %s\n", strconv.Quote(outputfile))
 	header += "# see https://rclone.org/bisync/#filtering\n"
+	header += fmt.Sprintf("\n# To generate:\n# rclone genfilters %s -o %s\n", strconv.Quote(fsPath), strconv.Quote(outputfile))
 	header += "\n# REMINDERS:\n# Do not leave any trailing whitespace after paths! (leading whitespace is fine)\n# order matters!\n"
 
 	_, err = fmt.Fprintf(file, "%s\n%s", header, rulesString)

--- a/cmd/genfilters/genfilters.go
+++ b/cmd/genfilters/genfilters.go
@@ -16,12 +16,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/atotto/clipboard"
 	"github.com/gdamore/tcell/v2"
 	"github.com/mattn/go-runewidth"
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/filter"
+	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/walk"
 	"github.com/rivo/tview"
 	"github.com/rivo/uniseg"
@@ -128,6 +130,8 @@ func helpText() (tr []string) {
 		" d toggle debug mode (shows more info)",
 		" r toggle showing the rules to the right of the tree",
 		" c clear selections and start over",
+		" y copy current relative path to clipboard (if supported)",
+		" Y copy current absolute path to clipboard (if supported)",
 		" q/ESC/^c to quit and output final results",
 	}
 	return
@@ -423,6 +427,14 @@ func GenFilters(ctx context.Context, f fs.Fs, infile, outfile string) error {
 			case 'i':
 				mode = includeOthers
 				startOver(tree)
+			case 'y':
+				if !clipboard.Unsupported {
+					_ = clipboard.WriteAll(nodeString(tree.GetCurrentNode()))
+				}
+			case 'Y':
+				if !clipboard.Unsupported {
+					_ = clipboard.WriteAll(fspath.JoinRootPath(fsPath, nodeString(tree.GetCurrentNode())))
+				}
 			}
 		}
 		return event

--- a/docs/content/commands/rclone.md
+++ b/docs/content/commands/rclone.md
@@ -881,6 +881,7 @@ rclone [flags]
 * [rclone delete](/commands/rclone_delete/)	 - Remove the files in path.
 * [rclone deletefile](/commands/rclone_deletefile/)	 - Remove a single file from remote.
 * [rclone gendocs](/commands/rclone_gendocs/)	 - Output markdown docs for rclone to the directory supplied.
+* [rclone genfilters](/commands/rclone_genfilters/)	 - Generate filters automatically with a terminal-based user interface.
 * [rclone hashsum](/commands/rclone_hashsum/)	 - Produces a hashsum file for all the objects in the path.
 * [rclone link](/commands/rclone_link/)	 - Generate public link to file/folder.
 * [rclone listremotes](/commands/rclone_listremotes/)	 - List all the remotes in the config file and defined in environment variables.

--- a/docs/content/commands/rclone_genfilters.md
+++ b/docs/content/commands/rclone_genfilters.md
@@ -43,6 +43,8 @@ You can interact with the user interface using key presses. The supported keys a
      d toggle debug mode (shows more info)
      r toggle showing the rules to the right of the tree
      c clear selections and start over
+     y copy current relative path to clipboard (if supported)
+     Y copy current absolute path to clipboard (if supported)
      q/ESC/^c to quit and output final results
 
 See flags for more options.
@@ -61,8 +63,9 @@ rclone genfilters remote:path [flags]
 ```
       --cmd                  Also show filters in command line syntax, to add the filters directly via the --filter flag instead of with a --filter-from file
   -h, --help                 help for genfilters
+      --input-file string    Load filters from this existing file on startup.
       --no-open              Do not automatically open the file when completed.
-  -o, --output-file string   Write results to a file at this path, for use as a --filter-from file. (default: {cachedir}/rclone_genfilters.txt)
+  -o, --output-file string   Write results to a file at this path, for use as a --filter-from file. (default: {currentdirectory}/rclone_genfilters.txt)
       --regex                Also show output as regex, in --dump filters format
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/putdotio/go-putio/putio v0.0.0-20200123120452-16d982cac2b8
 	github.com/rfjakob/eme v1.1.2
+	github.com/rivo/tview v0.0.0-20231206124440-5f078138442e
 	github.com/rivo/uniseg v0.4.4
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3
@@ -155,7 +156,6 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93 // indirect
 	github.com/relvacode/iso8601 v1.3.0 // indirect
-	github.com/rivo/tview v0.0.0-20231206124440-5f078138442e // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,6 @@ github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uq
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
-github.com/gdamore/tcell/v2 v2.6.0 h1:OKbluoP9VYmJwZwq/iLb4BxwKcwGthaa1YNBJIyCySg=
-github.com/gdamore/tcell/v2 v2.6.0/go.mod h1:be9omFATkdr0D9qewWW3d+MEvl5dha+Etb5y65J2H8Y=
 github.com/gdamore/tcell/v2 v2.6.1-0.20231203215052-2917c3801e73 h1:SeDV6ZUSVlTAUUPdMzPXgMyj96z+whQJRRUff8dIeic=
 github.com/gdamore/tcell/v2 v2.6.1-0.20231203215052-2917c3801e73/go.mod h1:pwzJMyH4Hd0AZMJkWQ+/g01dDvYWEvmJuaiRU71Xl8k=
 github.com/geoffgarside/ber v1.1.0 h1:qTmFG4jJbwiSzSXoNJeHcOprVzZ8Ulde2Rrrifu5U9w=


### PR DESCRIPTION
Changes summary:

- default to current directory instead of rclone cache dir if `-o` is not specified
- add support for loading an `--input-file` on startup
- fix case-insensitive sorting
- include example command in output
- make columns responsive to terminal width
- add support for copying the current path to clipboard
- docs updates